### PR TITLE
Fixing spelling error in command pyton instead of python

### DIFF
--- a/podman-docker-alternative/README.md
+++ b/podman-docker-alternative/README.md
@@ -30,7 +30,7 @@ sudo apt install podman
 ### 1.2. Install Podman-Compose
 
 ```
-sudo apt install pyton3-pip
+sudo apt install python3-pip
 pip3 install podman-compose
 ```
 


### PR DESCRIPTION
fix spelling on sudo apt install 'pyton3-pip'